### PR TITLE
Add separator argument to getLanguageLocale

### DIFF
--- a/src/Browser/Language.php
+++ b/src/Browser/Language.php
@@ -112,7 +112,7 @@ class Language
      *
      * @return  string
      */
-    public static function getLanguageLocale()
+    public static function getLanguageLocale($separator = '-')
     {
         if (!is_array(self::$languages)) {
             self::checkLanguages();
@@ -127,7 +127,7 @@ class Language
         }
 
         if (!empty($locale)) {
-            return $userLanguage . "-" . strtoupper($locale);
+            return $userLanguage . $separator . strtoupper($locale);
         } else {
             return $userLanguage;
         }


### PR DESCRIPTION
Allow overriding the default separator for getLanguageLocale.  It's sometimes useful to have the locale with an underscore instead of a dash.
