### PR TITLE
Fix branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "4.1-dev"
+            "dev-develop": "5.0-dev"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Due to the change of namespaces we need to point the current master branch against 5.0