### PR TITLE
Allow PHPUnit 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Allow the latest major version of PHPUnit. We can't be explicit with 5.0 since it requires PHP 5.6+ but we can allow it.