### PR TITLE
Assert same instead of equals

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -152,7 +152,7 @@ class Browser
             BrowserDetector::detect($this, $this->getUserAgent());
         }
 
-        return $this->version;
+        return (string) $this->version;
     }
 
     /**

--- a/src/Os.php
+++ b/src/Os.php
@@ -100,11 +100,11 @@ class Os
     public function getVersion()
     {
         if (isset($this->version)) {
-            return $this->version;
+            return (string) $this->version;
         } else {
             OsDetector::detect($this, $this->getUserAgent());
 
-            return $this->version;
+            return (string) $this->version;
         }
     }
 

--- a/tests/BrowserDetector/Tests/AcceptLanguageTest.php
+++ b/tests/BrowserDetector/Tests/AcceptLanguageTest.php
@@ -13,9 +13,9 @@ class AcceptLanguageTest extends PHPUnit_Framework_TestCase
         $this->assertNull($acceptLanguage->getAcceptLanguageString());
 
         $acceptLanguage = new AcceptLanguage('my_accept_language_string');
-        $this->assertEquals('my_accept_language_string', $acceptLanguage->getAcceptLanguageString());
+        $this->assertSame('my_accept_language_string', $acceptLanguage->getAcceptLanguageString());
 
         $acceptLanguage->setAcceptLanguageString('my_new_accept_language_string');
-        $this->assertEquals('my_new_accept_language_string', $acceptLanguage->getAcceptLanguageString());
+        $this->assertSame('my_new_accept_language_string', $acceptLanguage->getAcceptLanguageString());
     }
 }

--- a/tests/BrowserDetector/Tests/BrowserDetectorTest.php
+++ b/tests/BrowserDetector/Tests/BrowserDetectorTest.php
@@ -12,8 +12,8 @@ class BrowserDetectorTest extends PHPUnit_Framework_TestCase
         $userAgentStringCollection = UserAgentStringMapper::map();
         foreach ($userAgentStringCollection as $userAgentString) {
             $browser = new Browser($userAgentString->getString());
-            $this->assertEquals($userAgentString->getBrowser(), $browser->getName());
-            $this->assertEquals($userAgentString->getBrowserVersion(), $browser->getVersion());
+            $this->assertSame($userAgentString->getBrowser(), $browser->getName());
+            $this->assertSame($userAgentString->getBrowserVersion(), $browser->getVersion());
         }
     }
 }

--- a/tests/BrowserDetector/Tests/BrowserTest.php
+++ b/tests/BrowserDetector/Tests/BrowserTest.php
@@ -11,54 +11,54 @@ class BrowserTest extends PHPUnit_Framework_TestCase
     public function testBlackBerry()
     {
         $browser = new Browser('BlackBerry8100/4.5.0.124 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/100');
-        $this->assertEquals(Browser::BLACKBERRY, $browser->getName());
-        $this->assertEquals('4.5.0.124', $browser->getVersion());
+        $this->assertSame(Browser::BLACKBERRY, $browser->getName());
+        $this->assertSame('4.5.0.124', $browser->getVersion());
     }
 
     public function testFirefox()
     {
         $browser = new Browser('Mozilla/5.0 (X11; Linux x86_64; rv:18.0) Gecko/20100101 Firefox/18.0');
-        $this->assertEquals(Browser::FIREFOX, $browser->getName());
-        $this->assertEquals('18.0', $browser->getVersion());
+        $this->assertSame(Browser::FIREFOX, $browser->getName());
+        $this->assertSame('18.0', $browser->getVersion());
     }
 
     public function testInternetExplorer11()
     {
         $browser = new Browser('Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko');
-        $this->assertEquals(Browser::IE, $browser->getName());
-        $this->assertEquals('11.0', $browser->getVersion());
+        $this->assertSame(Browser::IE, $browser->getName());
+        $this->assertSame('11.0', $browser->getVersion());
 
         $browser = new Browser('Mozilla/5.0 (MSIE 9.0; Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko');
-        $this->assertEquals(Browser::IE, $browser->getName());
-        $this->assertEquals('11.0', $browser->getVersion());
+        $this->assertSame(Browser::IE, $browser->getName());
+        $this->assertSame('11.0', $browser->getVersion());
 
         $browser = new Browser('Mozilla/5.0 (MSIE 9.0; Windows NT 6.3; WOW64; Trident/7.0;) like Gecko');
-        $this->assertEquals(Browser::IE, $browser->getName());
-        $this->assertEquals('9.0', $browser->getVersion());
+        $this->assertSame(Browser::IE, $browser->getName());
+        $this->assertSame('9.0', $browser->getVersion());
     }
 
     public function testSeaMonkey()
     {
         $browser = new Browser('Mozilla/5.0 (Windows; U; Windows NT 5.1; RW; rv:1.8.0.7) Gecko/20110321 MultiZilla/4.33.2.6a SeaMonkey/8.6.55');
-        $this->assertEquals(Browser::SEAMONKEY, $browser->getName());
-        $this->assertEquals('8.6.55', $browser->getVersion());
+        $this->assertSame(Browser::SEAMONKEY, $browser->getName());
+        $this->assertSame('8.6.55', $browser->getVersion());
     }
 
     public function testUnknown()
     {
         $browser = new Browser();
-        $this->assertEquals(Browser::UNKNOWN, $browser->getName());
-        $this->assertEquals(Browser::VERSION_UNKNOWN, $browser->getVersion());
+        $this->assertSame(Browser::UNKNOWN, $browser->getName());
+        $this->assertSame(Browser::VERSION_UNKNOWN, $browser->getVersion());
     }
 
     public function testOpera()
     {
         $browser = new Browser('Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14');
-        $this->assertEquals(Browser::OPERA, $browser->getName());
-        $this->assertEquals('12.14', $browser->getVersion());
+        $this->assertSame(Browser::OPERA, $browser->getName());
+        $this->assertSame('12.14', $browser->getVersion());
 
         $browser = new Browser('Mozilla/5.0 (SunOS 5.8 sun4u; U) Opera 5.0 [en]');
-        $this->assertEquals(Browser::OPERA, $browser->getName());
-        $this->assertEquals('5.0', $browser->getVersion());
+        $this->assertSame(Browser::OPERA, $browser->getName());
+        $this->assertSame('5.0', $browser->getVersion());
     }
 }

--- a/tests/BrowserDetector/Tests/DeviceDetectorTest.php
+++ b/tests/BrowserDetector/Tests/DeviceDetectorTest.php
@@ -14,7 +14,7 @@ class DeviceDetectorTest extends PHPUnit_Framework_TestCase
         $userAgentStringCollection = UserAgentStringMapper::map();
         foreach ($userAgentStringCollection as $userAgentString) {
             $device = new Device($userAgentString->getString());
-            $this->assertEquals($userAgentString->getDevice(), $device->getName());
+            $this->assertSame($userAgentString->getDevice(), $device->getName());
         }
     }
 }

--- a/tests/BrowserDetector/Tests/DeviceTest.php
+++ b/tests/BrowserDetector/Tests/DeviceTest.php
@@ -10,6 +10,6 @@ class DeviceTest extends PHPUnit_Framework_TestCase
     public function testDevice()
     {
         $device = new Device();
-        $this->assertEquals(Device::UNKNOWN, $device->getName());
+        $this->assertSame(Device::UNKNOWN, $device->getName());
     }
 }

--- a/tests/BrowserDetector/Tests/LanguageTest.php
+++ b/tests/BrowserDetector/Tests/LanguageTest.php
@@ -21,7 +21,7 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 
     public function testGetLanguage()
     {
-        $this->assertEquals('fr', $this->language->getLanguage());
+        $this->assertSame('fr', $this->language->getLanguage());
     }
 
     public function testGetLanguages()
@@ -31,7 +31,7 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 
     public function testGetLanguageLocal()
     {
-        $this->assertEquals('fr-CA', $this->language->getLanguageLocale());
+        $this->assertSame('fr-CA', $this->language->getLanguageLocale());
     }
 
     public function testConstructor()
@@ -54,6 +54,6 @@ class LanguageTest extends PHPUnit_Framework_TestCase
     public function testGetLanguageLocale()
     {
         $language = new Language('ru,en-us;q=0.5,en;q=0.3');
-        $this->assertEquals('ru', $language->getLanguageLocale());
+        $this->assertSame('ru', $language->getLanguageLocale());
     }
 }

--- a/tests/BrowserDetector/Tests/OsDetectorTest.php
+++ b/tests/BrowserDetector/Tests/OsDetectorTest.php
@@ -12,8 +12,8 @@ class OsDetectorTest extends PHPUnit_Framework_TestCase
         $userAgentStringCollection = UserAgentStringMapper::map();
         foreach ($userAgentStringCollection as $userAgentString) {
             $os = new Os($userAgentString->getString());
-            $this->assertEquals($userAgentString->getOs(), $os->getName());
-            $this->assertEquals($userAgentString->getosVersion(), $os->getVersion());
+            $this->assertSame($userAgentString->getOs(), $os->getName());
+            $this->assertSame($userAgentString->getosVersion(), $os->getVersion());
         }
     }
 }

--- a/tests/BrowserDetector/Tests/OsTest.php
+++ b/tests/BrowserDetector/Tests/OsTest.php
@@ -12,29 +12,29 @@ class OsTest extends PHPUnit_Framework_TestCase
     public function testIOs()
     {
         $os = new Os('Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25');
-        $this->assertEquals(Os::IOS, $os->getName());
-        $this->assertEquals('6.0', $os->getVersion());
+        $this->assertSame(Os::IOS, $os->getName());
+        $this->assertSame('6.0', $os->getVersion());
     }
 
     public function testOsX()
     {
         $os = new Os('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/536.26.17 (KHTML, like Gecko) Version/6.0.2 Safari/536.26.17');
-        $this->assertEquals(Os::OSX, $os->getName());
-        $this->assertEquals('10.8.2', $os->getVersion());
+        $this->assertSame(Os::OSX, $os->getName());
+        $this->assertSame('10.8.2', $os->getVersion());
     }
 
     public function testOsX1010()
     {
         $os = new Os('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:34.0) Gecko/20100101 Firefox/34.0');
-        $this->assertEquals(Os::OSX, $os->getName());
-        $this->assertEquals('10.10', $os->getVersion());
+        $this->assertSame(Os::OSX, $os->getName());
+        $this->assertSame('10.10', $os->getVersion());
     }
 
     public function testBlackberry()
     {
         $os = new Os('Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+');
-        $this->assertEquals(Os::BLACKBERRY, $os->getName());
-        $this->assertEquals(Os::VERSION_UNKNOWN, $os->getVersion());
+        $this->assertSame(Os::BLACKBERRY, $os->getName());
+        $this->assertSame(Os::VERSION_UNKNOWN, $os->getVersion());
     }
 
     public function testIsMobile()
@@ -46,8 +46,8 @@ class OsTest extends PHPUnit_Framework_TestCase
     public function testWindows()
     {
         $os = new Os('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)');
-        $this->assertEquals(Os::WINDOWS, $os->getName());
-        $this->assertEquals('7', $os->getVersion());
+        $this->assertSame(Os::WINDOWS, $os->getName());
+        $this->assertSame('7', $os->getVersion());
     }
 
     public function testConstructor()
@@ -71,13 +71,13 @@ class OsTest extends PHPUnit_Framework_TestCase
         $userAgent = new UserAgent('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)');
         $os = new Os($userAgent);
 
-        $this->assertEquals('7', $os->getVersion());
+        $this->assertSame('7', $os->getVersion());
     }
 
     public function testUnknown()
     {
         $os = new Os('');
-        $this->assertEquals(Os::UNKNOWN, $os->getName());
-        $this->assertEquals(Os::VERSION_UNKNOWN, $os->getVersion());
+        $this->assertSame(Os::UNKNOWN, $os->getName());
+        $this->assertSame(Os::VERSION_UNKNOWN, $os->getVersion());
     }
 }

--- a/tests/BrowserDetector/Tests/UserAgentTest.php
+++ b/tests/BrowserDetector/Tests/UserAgentTest.php
@@ -13,9 +13,9 @@ class UserAgentTest extends PHPUnit_Framework_TestCase
         $this->assertNull($userAgent->getUserAgentString());
 
         $userAgent = new UserAgent('my_agent_user_string');
-        $this->assertEquals('my_agent_user_string', $userAgent->getUserAgentString());
+        $this->assertSame('my_agent_user_string', $userAgent->getUserAgentString());
 
         $userAgent->setUserAgentString('my_new_agent_user_string');
-        $this->assertEquals('my_new_agent_user_string', $userAgent->getUserAgentString());
+        $this->assertSame('my_new_agent_user_string', $userAgent->getUserAgentString());
     }
 }

--- a/tests/BrowserDetector/Tests/_includes/UserAgentString.php
+++ b/tests/BrowserDetector/Tests/_includes/UserAgentString.php
@@ -84,7 +84,7 @@ class UserAgentString
      */
     public function getosVersion()
     {
-        return $this->osVersion;
+        return (string) $this->osVersion;
     }
 
     /**
@@ -124,7 +124,7 @@ class UserAgentString
      */
     public function getbrowserVersion()
     {
-        return $this->browserVersion;
+        return (string) $this->browserVersion;
     }
 
     /**


### PR DESCRIPTION
This allows us to be more strict. There were two places which this broke and were we couldn't use `asserSame` even though both methods says they are returning `string`. 

First it is this one in `OsDetectorTest`.
```php
$this->assertEquals($userAgentString->getosVersion(), $os->getVersion());
```

The second one was in `BrowserDetectorTest`.
```php
$this->assertEquals($userAgentString->getBrowserVersion(), $browser->getVersion());
```

I guess this should be considered as a bug. Since they are returning an `int` instead of a `string`. What do you think?