### PR TITLE
Don't allow failure on HHVM and add PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-  - nightly
 
 before_script:
   ## Composer
@@ -18,7 +18,3 @@ before_script:
 
 script:
   - phpunit
-
-matrix:
-  allow_failures:
-    - php: hhvm


### PR DESCRIPTION
Added tests on 7.0 and removed the option to allow HHVM to fail.