### PR TITLE
Update PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": "^5.3.3 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0 || ^5.0"


### PR DESCRIPTION
Since the release of PHP 7.0 people have started updating their packages to only allow specific versions of PHP. We wont know if something will break in PHP 8.0 for example.