### PR TITLE
Feature/compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ reliable and evolves at all time, use with care and feel free to contribute.
 This library uses PHP 5.3+.
 
 ## Install
-    
+
 It is recommended that you install the PHP Browser library [through composer](http://getcomposer.org). To do so, run the following command:
 
 ```sh
@@ -77,6 +77,20 @@ $browser = new Browser();
 
 if ($browser->getName() === Browser::IE && $browser->getVersion() < 11) {
     echo 'Please upgrade your browser.';
+}
+```
+
+#### Compatibility Mode
+
+Detect if Internet Explorer is in Compatibility Mode and send the correct header to have the browser render the page in its standard mode. This must be called before any output is sent to the browser.
+
+```php
+use Sinergi\BrowserDetector\Browser;
+
+$browser = new Browser();
+
+if ($browser->getName() === Browser::IE && $browser->isCompatibilityMode()) {
+    $browser->endCompatibilityMode();
 }
 ```
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -270,4 +270,12 @@ class Browser
         return $this->isCompatibilityMode;
     }
 
+    /**
+     * Render pages outside of IE's compatibility mode.
+     */
+    public function endCompatibilityMode()
+    {
+        header('X-UA-Compatible: IE=edge');
+    }
+
 }

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -72,6 +72,11 @@ class Browser
     private $isChromeFrame = false;
 
     /**
+     * @var bool
+     */
+    private $isCompatibilityMode = false;
+
+    /**
      * @param null|string|UserAgent $userAgent
      *
      * @throws \Sinergi\BrowserDetector\InvalidArgumentException
@@ -244,4 +249,25 @@ class Browser
     {
         return $this->userAgent;
     }
+
+    /**
+    * @param bool
+    *
+    * @return $this
+    */
+    public function setIsCompatibilityMode($isCompatibilityMode)
+    {
+      $this->isCompatibilityMode = $isCompatibilityMode;
+
+      return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCompatibilityMode()
+    {
+        return $this->isCompatibilityMode;
+    }
+
 }

--- a/src/BrowserDetector.php
+++ b/src/BrowserDetector.php
@@ -198,6 +198,39 @@ class BrowserDetector implements DetectorInterface
                     if (isset($matches[1])) {
                         self::$browser->setVersion($matches[1]);
                     }
+
+                    // At this poing in the method, we know the MSIE and Trident
+                    // strings are present in the $userAgentString. If we're in
+                    // compatibility mode, we need to determine the true version.
+                    // If the MSIE version is 7.0, we can look at the Trident
+                    // version to *approximate* the true IE version. If we don't
+                    // find a matching pair, ( e.g. MSIE 7.0 && Trident/7.0 )
+                    // we're *not* in compatibility mode and the browser really
+                    // is version 7.0.
+                    if (stripos(self::$userAgentString, 'MSIE 7.0;'))
+                    {
+                      // IE11 in compatibility mode
+                      if (stripos(self::$userAgentString, 'Trident/7.0;')) {
+                          self::$browser->setVersion('11.0');
+                          self::$browser->setIsCompatibilityMode(true);
+                      }
+                      // IE10 in compatibility mode
+                      else if (stripos(self::$userAgentString, 'Trident/6.0;')) {
+                          self::$browser->setVersion('10.0');
+                          self::$browser->setIsCompatibilityMode(true);
+                      }
+                      // IE9 in compatibility mode
+                      else if (stripos(self::$userAgentString, 'Trident/5.0;')) {
+                          self::$browser->setVersion('9.0');
+                          self::$browser->setIsCompatibilityMode(true);
+                      }
+                      // IE8 in compatibility mode
+                      else if (stripos(self::$userAgentString, 'Trident/4.0;')) {
+                          self::$browser->setVersion('8.0');
+                          self::$browser->setIsCompatibilityMode(true);
+                      }
+                    }
+
                 }
 
                 return true;

--- a/tests/BrowserDetector/Tests/_files/UserAgentStrings.xml
+++ b/tests/BrowserDetector/Tests/_files/UserAgentStrings.xml
@@ -153,5 +153,49 @@
                 Mozilla/5.0 (X11; CrOS x86_64 7520.62.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.80 Safari/537.36
             </field>
         </string>
+        <string>
+            <field name="browser">Internet Explorer</field>
+            <field name="version">8.0</field>
+            <field name="os">Windows</field>
+            <field name="os_version">7</field>
+            <field name="device">unknown</field>
+            <field name="device_version">unknown</field>
+            <field name="string">
+                Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E)
+            </field>
+        </string>
+        <string>
+            <field name="browser">Internet Explorer</field>
+            <field name="version">9.0</field>
+            <field name="os">Windows</field>
+            <field name="os_version">7</field>
+            <field name="device">unknown</field>
+            <field name="device_version">unknown</field>
+            <field name="string">
+                Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E)
+            </field>
+        </string>
+        <string>
+            <field name="browser">Internet Explorer</field>
+            <field name="version">10.0</field>
+            <field name="os">Windows</field>
+            <field name="os_version">7</field>
+            <field name="device">unknown</field>
+            <field name="device_version">unknown</field>
+            <field name="string">
+                Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E)
+            </field>
+        </string>
+        <string>
+            <field name="browser">Internet Explorer</field>
+            <field name="version">11.0</field>
+            <field name="os">Windows</field>
+            <field name="os_version">7</field>
+            <field name="device">unknown</field>
+            <field name="device_version">unknown</field>
+            <field name="string">
+                Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E)
+            </field>
+        </string>
     </strings>
 </document>


### PR DESCRIPTION
Currently, BrowserDetector::checkBrowserInternetExplorer() will recognize any version of IE in Compatibility Mode as IE7. This feature set adds a routine to correct the browser version such that IE8-11 are correctly reported even when in compatibility mode. This update also adds three new methods to the Brower class. The first is called from BrowserDetector to set a bool value for a new var $isCompatibilityMode. The second is a getter for that value, returning true if the browser is in compatibility mode and false if it is not. A third method is documented in an updated README.md that allows a developer to pass the required header to have IE render a page outside of compatibility mode. Also, UserAgentStrings.xml has been updated with test strings for IE8-11 in compatibility mode.