### PR TITLE
Remove default type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "sinergi/browser-detector",
-    "type": "library",
     "description": "Detecting the user's browser, operating system and language.",
     "keywords": ["browser", "os", "operating system", "language", "detection"],
     "license": "MIT",


### PR DESCRIPTION
We can remove the type parameter since `library` is default.

https://getcomposer.org/doc/04-schema.md#type