### PR TITLE
Detection from Microsoft Edge Version returns the HTML Version

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -38,6 +38,7 @@ class Browser
     const GSA = 'Google Search Appliance';
     const YANDEX = 'Yandex';
     const EDGE = 'Edge';
+    const EDGE_HTML = 'EdgeHTML';
     const DRAGON = 'Dragon';
     const NSPLAYER = 'Windows Media Player';
     const UCBROWSER = 'UC Browser';

--- a/src/BrowserDetector.php
+++ b/src/BrowserDetector.php
@@ -71,6 +71,72 @@ class BrowserDetector implements DetectorInterface
         'Mozilla', /* Mozilla is such an open standard that you must check it last */
     );
 
+    //https://en.wikipedia.org/wiki/Microsoft_Edge
+    protected static $edgeHTML = [
+        "12.10049" => "0.10.10049",
+        "12.10051" => "0.11.10051",
+        "12.10052" => "0.11.10052",
+        "12.10061" => "0.11.10061",
+        "12.10074" => "0.11.10074",
+        "12.1008" => "0.11.10080",
+        "12.10122" => "13.10122",
+        "12.1013" => "15.1013",
+        "12.10136" => "16.10136",
+        "12.10149" => "19.10149",
+        "12.10158" => "20.10158",
+        "12.10159" => "20.10159",
+        "12.10162" => "20.10162",
+        "12.10166" => "20.10166",
+        "12.1024" => "20.1024",
+        "12.10512" => "20.10512",
+        "12.10514" => "20.10514",
+        "12.10525" => "20.10525",
+        "12.10532" => "20.10532",
+        "12.10536" => "20.10536",
+        "13.10547" => "21.10547",
+        "13.10549" => "21.10549",
+        "13.10565" => "23.10565",
+        "13.10572" => "25.10572",
+        "13.10576" => "25.10576",
+        "13.10581" => "25.10581",
+        "13.10586" => "25.10586",
+        "13.11082" => "25.11082",
+        "13.11099" => "27.11099",
+        "13.11102" => "28.11102",
+        "13.14251" => "28.14251",
+        "13.14257" => "28.14257",
+        "14.14267" => "31.14267",
+        "14.14271" => "31.14271",
+        "14.14279" => "31.14279",
+        "14.14283" => "31.14283",
+        "14.14291" => "34.14291",
+        "14.14295" => "34.14295",
+        "14.143" => "34.143",
+        "14.14316" => "37.14316",
+        "14.14322" => "37.14322",
+        "14.14327" => "37.14327",
+        "14.14328" => "37.14328",
+        "14.14332" => "37.14332",
+        "14.14342" => "38.14342",
+        "14.14352" => "38.14352",
+        "14.14393" => "38.14393",
+        "14.14901" => "39.14901",
+        "14.14905" => "39.14905",
+        "14.14915" => "39.14915",
+        "14.14926" => "39.14926",
+        "14.14931" => "39.14931",
+        "14.14936" => "39.14936",
+        "15.14942" => "39.14942",
+        "15.14946" => "39.14946",
+        "15.14951" => "39.14951",
+        "15.14955" => "39.14955",
+        "15.14959" => "39.14959",
+        "15.14965" => "39.14965",
+        "15.14971" => "39.14971",
+        "15.14977" => "39.14977",
+        "15.14986" => "39.14986"
+    ];
+
     /**
      * Routine to determine the browser type.
      *
@@ -473,11 +539,24 @@ class BrowserDetector implements DetectorInterface
     public static function checkBrowserEdge()
     {
         if (stripos(self::$userAgentString, 'Edge') !== false) {
-            $version = explode('Edge/', self::$userAgentString);
-            if (isset($version[1])) {
-                self::$browser->setVersion((float)$version[1]);
+            preg_match('/Edge[\\/ \\(]([a-zA-Z\\d\\.]*)/i', self::$userAgentString, $matches);
+            if (sizeof($matches)>1)
+            {
+                if (isset(self::$edgeHTML[$matches[1]]))
+                {
+                    self::$browser->setName(Browser::EDGE);
+                    self::$browser->setVersion(self::$edgeHTML[$matches[1]]);
+                }
+                else
+                {
+                    self::$browser->setName(Browser::EDGE_HTML);
+                    self::$browser->setVersion($matches[1]);
+                }
             }
-            self::$browser->setName(Browser::EDGE);
+            else
+            {
+                self::$browser->setName(Browser::EDGE);
+            }
 
             return true;
         }
@@ -962,7 +1041,7 @@ class BrowserDetector implements DetectorInterface
 
         return false;
     }
-    
+
     /**
      * Determine if the browser is Comodo Dragon / Ice Dragon / Chromodo.
      *

--- a/tests/BrowserDetector/Tests/_files/UserAgentStrings.xml
+++ b/tests/BrowserDetector/Tests/_files/UserAgentStrings.xml
@@ -110,7 +110,7 @@
         </string>
         <string>
             <field name="browser">Edge</field>
-            <field name="version">12.10136</field>
+            <field name="version">16.10136</field>
             <field name="os">Windows</field>
             <field name="os_version">10.0</field>
             <field name="device">unknown</field>
@@ -232,7 +232,7 @@
         </string>
         <string>
             <field name="browser">Edge</field>
-            <field name="version">14.14393</field>
+            <field name="version">38.14393</field>
             <field name="os">Windows Phone</field>
             <field name="os_version">10</field>
             <field name="device">Lumia 640 LTE</field>

--- a/tests/BrowserDetector/Tests/_files/UserAgentStrings.xml
+++ b/tests/BrowserDetector/Tests/_files/UserAgentStrings.xml
@@ -242,6 +242,17 @@
             </field>
         </string>
         <string>
+            <field name="browser">EdgeHTML</field>
+            <field name="version">12.00049</field>
+            <field name="os">Windows Phone</field>
+            <field name="os_version">10</field>
+            <field name="device">Lumia 640 LTE</field>
+            <field name="device_version">unknown</field>
+            <field name="string">
+                Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 640 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Mobile Safari/537.36 Edge/12.00049
+            </field>
+        </string>
+        <string>
             <field name="browser">BlackBerry</field>
             <field name="version">7.1.0.523</field>
             <field name="os">BlackBerry</field>


### PR DESCRIPTION
Suggested fix for #77 

This adds a lookup table for Edge. This will require some maintenance.

If the version cannot be resolved, the browser name "EdgeHTML" is returned rather than "Edge", so that the version number is not misleading.

Also fixed regex for edge.