### PR TITLE
PHP 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ env:
   - APP_ENV=travis
 
 php:
-  - 5.3.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+  - nightly #php 8
   - hhvm
 
 before_script:
@@ -17,7 +15,3 @@ before_script:
 
 script:
   - phpunit
-
-matrix:
-  allow_failures:
-    - php: 5.3.3

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0"
+        "php": ">=7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.0"
+        "phpunit/phpunit": "^8.0 || ^9.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
-         bootstrap="tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true"
+         bootstrap="tests/bootstrap.php" colors="true" convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false"
+         stopOnError="false" stopOnFailure="false" verbose="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Browser Detector Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/BrowserDetector/Tests/AcceptLanguageTest.php
+++ b/tests/BrowserDetector/Tests/AcceptLanguageTest.php
@@ -2,10 +2,10 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Sinergi\BrowserDetector\AcceptLanguage;
 
-class AcceptLanguageTest extends PHPUnit_Framework_TestCase
+class AcceptLanguageTest extends TestCase
 {
     public function testObject()
     {

--- a/tests/BrowserDetector/Tests/BrowserDetectorTest.php
+++ b/tests/BrowserDetector/Tests/BrowserDetectorTest.php
@@ -2,10 +2,10 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Sinergi\BrowserDetector\Browser;
 
-class BrowserDetectorTest extends PHPUnit_Framework_TestCase
+class BrowserDetectorTest extends TestCase
 {
     public function testDetect()
     {

--- a/tests/BrowserDetector/Tests/BrowserTest.php
+++ b/tests/BrowserDetector/Tests/BrowserTest.php
@@ -2,11 +2,11 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Sinergi\BrowserDetector\Browser;
 
 // todo: move to browser detector tests
-class BrowserTest extends PHPUnit_Framework_TestCase
+class BrowserTest extends TestCase
 {
     public function testBlackBerry()
     {

--- a/tests/BrowserDetector/Tests/DeviceDetectorTest.php
+++ b/tests/BrowserDetector/Tests/DeviceDetectorTest.php
@@ -2,12 +2,10 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Sinergi\BrowserDetector\Device;
-use Sinergi\BrowserDetector\DeviceDetector;
-use Sinergi\BrowserDetector\UserAgent;
 
-class DeviceDetectorTest extends PHPUnit_Framework_TestCase
+class DeviceDetectorTest extends TestCase
 {
     public function testDeviceDetect()
     {

--- a/tests/BrowserDetector/Tests/DeviceTest.php
+++ b/tests/BrowserDetector/Tests/DeviceTest.php
@@ -2,10 +2,10 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Sinergi\BrowserDetector\Device;
 
-class DeviceTest extends PHPUnit_Framework_TestCase
+class DeviceTest extends TestCase
 {
     public function testDevice()
     {

--- a/tests/BrowserDetector/Tests/LanguageTest.php
+++ b/tests/BrowserDetector/Tests/LanguageTest.php
@@ -2,18 +2,19 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Sinergi\BrowserDetector\AcceptLanguage;
+use Sinergi\BrowserDetector\InvalidArgumentException;
 use Sinergi\BrowserDetector\Language;
 
-class LanguageTest extends PHPUnit_Framework_TestCase
+class LanguageTest extends TestCase
 {
     /**
      * @var Language
      */
     private $language;
 
-    public function setUp()
+    public function setUp(): void
     {
         $httpAcceptLanguage = 'fr-CA,fr;q=0.8,en-CA;q=0.6,en;q=0.4,en-US;q=0.2';
         $this->language = new Language($httpAcceptLanguage);
@@ -43,12 +44,10 @@ class LanguageTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf("\\Sinergi\\BrowserDetector\\Language", $language);
     }
 
-    /**
-     * @expectedException \Sinergi\BrowserDetector\InvalidArgumentException
-     */
     public function testConstructorException()
     {
-        $language = new Language(1);
+        $this->expectException(InvalidArgumentException::class);
+        new Language(1);
     }
 
     public function testGetLanguageLocale()

--- a/tests/BrowserDetector/Tests/OsDetectorTest.php
+++ b/tests/BrowserDetector/Tests/OsDetectorTest.php
@@ -2,10 +2,10 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Sinergi\BrowserDetector\Os;
 
-class OsDetectorTest extends PHPUnit_Framework_TestCase
+class OsDetectorTest extends TestCase
 {
     public function testDetect()
     {

--- a/tests/BrowserDetector/Tests/OsTest.php
+++ b/tests/BrowserDetector/Tests/OsTest.php
@@ -2,12 +2,13 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use Sinergi\BrowserDetector\InvalidArgumentException;
 use Sinergi\BrowserDetector\Os;
 use Sinergi\BrowserDetector\UserAgent;
 
 // todo: move to os detector tests
-class OsTest extends PHPUnit_Framework_TestCase
+class OsTest extends TestCase
 {
     public function testIOs()
     {
@@ -60,12 +61,10 @@ class OsTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf("\\Sinergi\\BrowserDetector\\Os", $os);
     }
 
-    /**
-     * @expectedException \Sinergi\BrowserDetector\InvalidArgumentException
-     */
     public function testConstructorException()
     {
-        $os = new Os(1);
+        $this->expectException(InvalidArgumentException::class);
+        new Os(1);
     }
 
     public function testGetVersion()

--- a/tests/BrowserDetector/Tests/UserAgentTest.php
+++ b/tests/BrowserDetector/Tests/UserAgentTest.php
@@ -2,10 +2,10 @@
 
 namespace Sinergi\BrowserDetector\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Sinergi\BrowserDetector\UserAgent;
 
-class UserAgentTest extends PHPUnit_Framework_TestCase
+class UserAgentTest extends TestCase
 {
     public function testObject()
     {


### PR DESCRIPTION
Hi,

to prepare for the release of PHP 8, created this small PR with following changes:
- drop support for unmaintained php versions
- update requirements for newer php versions
- added newer php versions to travis config

Please let me know if you'd prefer any of this to be solved differently :)