### PR TITLE
Add support for legacy webOS Mobile devices

### DIFF
--- a/src/Os.php
+++ b/src/Os.php
@@ -25,6 +25,7 @@ class Os
     const BEOS = 'BeOS';
     const WINDOWS_PHONE = 'Windows Phone';
     const CHROME_OS = 'Chrome OS';
+    const WEBOS = "webOS";
 
     const VERSION_UNKNOWN = 'unknown';
 

--- a/src/OsDetector.php
+++ b/src/OsDetector.php
@@ -38,6 +38,8 @@ class OsDetector implements DetectorInterface
             self::checkBeOS($os, $userAgent) ||
             // Android before Linux
             self::checkAndroid($os, $userAgent) ||
+            // webOS before Linux
+            self::checkWebOS($os, $userAgent) ||
             self::checkLinux($os, $userAgent) ||
             self::checkNokia($os, $userAgent) ||
             self::checkBlackBerry($os, $userAgent)
@@ -499,6 +501,45 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'BeOS') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::BEOS);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the user's operating system is webOS.
+     *
+     * @param Os $os
+     * @param UserAgent $userAgent
+     *
+     * @return bool
+     */
+    private static function checkWebOS(Os $os, UserAgent $userAgent)
+    {
+        if (stripos($userAgent->getUserAgentString(), 'hpwOS') !== false) {
+            $aresult = explode('hpwOS/', $userAgent->getUserAgentString());
+            if (isset($aresult[1])) {
+                $aversion = explode(';', $aresult[1]);
+                $os->setVersion($aversion[0]);
+            } else {
+                $os->setVersion($os::VERSION_UNKNOWN);
+            }
+            $os->setName($os::WEBOS);
+            $os->setIsMobile(true);
+
+            return true;
+        } elseif (stripos($userAgent->getUserAgentString(), 'webOS') !== false) {
+            $aresult = explode('webOS/', $userAgent->getUserAgentString());
+            if (isset($aresult[1])) {
+                $aversion = explode(';', $aresult[1]);
+                $os->setVersion($aversion[0]);
+            } else {
+                $os->setVersion($os::VERSION_UNKNOWN);
+            }
+            $os->setName($os::WEBOS);
+            $os->setIsMobile(true);
 
             return true;
         }

--- a/tests/BrowserDetector/Tests/OsTest.php
+++ b/tests/BrowserDetector/Tests/OsTest.php
@@ -38,6 +38,13 @@ class OsTest extends TestCase
         $this->assertSame('7.1.0.346', $os->getVersion());
     }
 
+    public function testWebOS()
+    {
+        $os = new Os('Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0');
+        $this->assertSame(Os::WEBOS, $os->getName());
+        $this->assertSame('3.0.5', $os->getVersion());
+    }
+
     public function testIsMobile()
     {
         $os = new Os('Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 640 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Mobile Safari/537.36 Edge/14.14393');


### PR DESCRIPTION
This PR adds support for [legacy webOS mobile](https://en.wikipedia.org/wiki/WebOS#History) OS detection, for devices like the Palm Pre and the HP Touchpad. 

Similar to Android, the OS is Linux based, so the detection must precede the Linux function. There were two major variants of legacy webOS, one for phones, one for tablets and both are detected. (an unreleased prototype device may have a third variant, but they are so rare I was unable to acquire one to test.) A unit test was added for the tablet variant, which is the most common device still online, and all tests pass.
More about legacy webOS here: [www.webosarchive.com](http://www.webosarchive.com)

Modern webOS is owned by LG, is used for their Smart TVS, and the built-in browser has a different user agent string. I'll work on adding support for that in a future PR.