### PR TITLE
Fix and improve language detection

### DIFF
--- a/src/LanguageDetector.php
+++ b/src/LanguageDetector.php
@@ -36,7 +36,7 @@ class LanguageDetector implements DetectorInterface
                 $value = trim($value, ',; .');
                 if (is_numeric($value)) {
                     $key = $value;
-                } else if($value) {
+                } elseif ($value) {
                     $languages[$key] = preg_split('/[^\w-]+/', $value);
                 }
             }

--- a/src/LanguageDetector.php
+++ b/src/LanguageDetector.php
@@ -14,11 +14,15 @@ class LanguageDetector implements DetectorInterface
      */
     public static function detect(Language $language, AcceptLanguage $acceptLanguage)
     {
+        // Accept-Language header convention:
+        // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
+
         $acceptLanguageString = $acceptLanguage->getAcceptLanguageString();
         $languages = array();
         $language->setLanguages($languages);
 
         if (!empty($acceptLanguageString)) {
+            // Split by ranges (en-US,en;q=0.8) and keep priority value (0.8)
             $httpLanguages = preg_split(
                 '/q=([\d\.]*)/',
                 $acceptLanguageString,
@@ -26,20 +30,29 @@ class LanguageDetector implements DetectorInterface
                 PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
             );
 
+            // Group by priority
             $key = 0;
             foreach (array_reverse($httpLanguages) as $value) {
                 $value = trim($value, ',; .');
                 if (is_numeric($value)) {
                     $key = $value;
-                } else {
-                    $languages[$key] = explode(',', $value);
+                } else if($value) {
+                    $languages[$key] = preg_split('/[^\w-]+/', $value);
                 }
             }
+
+            // Sort by priority
             krsort($languages);
 
-            foreach ($languages as $value) {
-                $language->setLanguages(array_merge($language->getLanguages(), $value));
+            // Flatten array and remove duplicates
+            $result = [];
+            foreach ($languages as $values) {
+                foreach ($values as $value) {
+                    $result[$value] = true;
+                }
             }
+
+            $language->setLanguages(array_keys($result));
         }
     }
 }

--- a/tests/BrowserDetector/Tests/LanguageTest.php
+++ b/tests/BrowserDetector/Tests/LanguageTest.php
@@ -27,7 +27,8 @@ class LanguageTest extends TestCase
 
     public function testGetLanguages()
     {
-        $this->assertGreaterThan(0, count($this->language->getLanguages()));
+        $languages = ['fr-CA', 'fr', 'en-CA', 'en', 'en-US'];
+        $this->assertSame($languages, $this->language->getLanguages());
     }
 
     public function testGetLanguageLocal()
@@ -54,5 +55,11 @@ class LanguageTest extends TestCase
     {
         $language = new Language('ru,en-us;q=0.5,en;q=0.3');
         $this->assertSame('ru', $language->getLanguageLocale());
+    }
+
+    public function testGetLanguagesFromBogusHeader()
+    {
+        $language = new Language(';q=0.8, de, en;q=0.2, de-CH, de;q=0.4');
+        $this->assertSame(['de-CH', 'de', 'en'], $language->getLanguages());
     }
 }


### PR DESCRIPTION
Language.php line 93 `strpos($language, $userLanguage)` throws an error/warning when $userLanguage (first language in the languages array) is empty.

This happens when the header looks like `;q=1, en, de;q=0.5` starting with an empty language, but with a "q" value. I suggest to change the code in LanguageDetector.php from line 30 to this:

```php
foreach (array_reverse($httpLanguages) as $value) {
    $value = trim($value, ',; .');
    if (is_numeric($value)) {
        $key = $value;
    } elseif ($value) {
        $languages[$key] = preg_split('/[^\w-]+/', $value);
    }
}
```

This ensures that the value has an actual content and also (second problem) eliminates trailing spaces between languages using preg_split instead of explode. As a bonus you can also remove duplicate languages from the final array:

```php
$result = [];
foreach ($languages as $values) {
    foreach ($values as $value) {
        $result[$value] = true;
    }
}

$language->setLanguages(array_keys($result));
```